### PR TITLE
Fix: use-day hooks meridiem 변수 쉐도잉으로 발생한 비교 연산자 이슈

### DIFF
--- a/src/shared/hooks/use-day.ts
+++ b/src/shared/hooks/use-day.ts
@@ -22,9 +22,10 @@ const useDay = () => {
   useInterval(() => {
     const hours = dayjs(new Date()).format("h");
     const minutes = dayjs().get("minutes").toString().padStart(2, "0");
-    const meridiem = dayjs().get("h") >= 12 ? "PM" : "AM";
+    const newMeridiem = dayjs().get("h") >= 12 ? "PM" : "AM";
+
     if (`${hours}:${minutes}` !== time) setTime(`${hours}:${minutes}`);
-    if (meridiem !== meridiem) setMeridiem(meridiem);
+    if (meridiem !== newMeridiem) setMeridiem(newMeridiem);
   }, 1);
 
   return {


### PR DESCRIPTION
- state meridiem과 함수 스코프 안에 meridiem의 식별자가 동일하여 발생하는 변수 쉐도잉 수정